### PR TITLE
Optimise for large strings containing lots of whitespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
 'use strict';
 module.exports = function (str) {
-	return str.replace(/[\s\uFEFF\xA0]+$/g, '');
+  var tail = str.length;
+  while(/[\s\uFEFF\xA0]/.test(str[tail - 1])){
+    tail--;
+  }
+  return str.slice(0, tail);
 };


### PR DESCRIPTION
Ref babel/babel#2008:

> It looks like it's coming from the [trim-right in `Buffer#get`](https://github.com/babel/babel/blob/1f851153fd0d09f13d17a6d7ecf2e1404e418c30/packages/babel/src/generation/buffer.js#L24) (replacing that line with `return this.buf` makes everything fast again).
> 
> By the look of it, trim-right uses [a regex that's quadratically bad](https://github.com/sindresorhus/trim-right/blob/master/index.js#L3) if you have massive expanses of whitespace that _aren't_ at the end of the string

cc @jbt
